### PR TITLE
Add basic radial mind map interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# sol
+# Radial Mind Map
+
+This repository contains a simple Mindly-style radial mind map interface implemented with vanilla HTML, CSS and JavaScript.
+
+## Usage
+
+Open `index.html` in a modern browser. The central "Sun" bubble anchors the map; click a bubble to focus it, double‑click to edit text, and long‑press to add or remove child bubbles. A bottom navigation bar provides placeholder actions for home, overview, print and share.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Radial Mind Map</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="mindmap"></div>
+  <nav class="bottom-bar">
+    <button id="home">Home</button>
+    <button id="overview">Mindmap</button>
+    <button id="print">Print</button>
+    <button id="share">Share</button>
+  </nav>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,105 @@
+const data = {
+  text: 'Sun',
+  children: [
+    { text: 'Idea 1', children: [] },
+    { text: 'Idea 2', children: [] },
+    { text: 'Idea 3', children: [] },
+  ],
+};
+
+let currentNode = data;
+
+function render() {
+  const container = document.getElementById('mindmap');
+  container.innerHTML = '';
+
+  const center = createBubble(currentNode, true);
+  container.appendChild(center);
+
+  const radius = 150;
+  const count = currentNode.children.length;
+  currentNode.children.forEach((child, i) => {
+    const angle = (2 * Math.PI * i) / count;
+    const x = radius * Math.cos(angle);
+    const y = radius * Math.sin(angle);
+    const bubble = createBubble(child, false);
+    bubble.style.transform = `translate(${x}px, ${y}px)`;
+    container.appendChild(bubble);
+  });
+}
+
+function createBubble(node, isCenter) {
+  const div = document.createElement('div');
+  div.className = 'bubble' + (isCenter ? ' center' : '');
+  div.textContent = node.text;
+
+  div.addEventListener('click', () => {
+    if (node !== currentNode) {
+      currentNode = node;
+      render();
+    }
+  });
+
+  div.addEventListener('dblclick', () => {
+    div.contentEditable = true;
+    div.focus();
+  });
+
+  div.addEventListener('blur', () => {
+    div.contentEditable = false;
+    node.text = div.textContent;
+  });
+
+  let pressTimer;
+  div.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    pressTimer = setTimeout(() => showMenu(node, div), 600);
+  });
+  ['mouseup', 'mouseout'].forEach((ev) =>
+    div.addEventListener(ev, () => clearTimeout(pressTimer))
+  );
+
+  return div;
+}
+
+function showMenu(node, element) {
+  const menu = document.createElement('div');
+  menu.className = 'menu';
+
+  const add = document.createElement('button');
+  add.textContent = 'Add';
+  add.onclick = () => {
+    node.children.push({ text: 'New', children: [] });
+    render();
+  };
+  menu.appendChild(add);
+
+  if (node !== data) {
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.onclick = () => {
+      removeNode(data, node);
+      currentNode = data;
+      render();
+    };
+    menu.appendChild(del);
+  }
+
+  document.body.appendChild(menu);
+  const rect = element.getBoundingClientRect();
+  menu.style.left = rect.left + 'px';
+  menu.style.top = rect.top - 40 + 'px';
+
+  const dismiss = () => {
+    menu.remove();
+    document.body.removeEventListener('click', dismiss);
+  };
+  setTimeout(() => document.body.addEventListener('click', dismiss), 0);
+}
+
+function removeNode(parent, target) {
+  parent.children = parent.children.filter((ch) => ch !== target);
+  parent.children.forEach((ch) => removeNode(ch, target));
+}
+
+render();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,53 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  overflow: hidden;
+}
+
+#mindmap {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.bubble {
+  position: absolute;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: #ffd54f;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 5px;
+  cursor: pointer;
+  transition: transform 0.3s;
+}
+
+.center {
+  background: #ffb300;
+}
+
+.menu {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 4px;
+  border-radius: 4px;
+  z-index: 1000;
+}
+
+.bottom-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #eee;
+  display: flex;
+  justify-content: space-around;
+  padding: 10px 0;
+}


### PR DESCRIPTION
## Summary
- Implement simple radial mind map with center “sun” and orbiting child bubbles.
- Enable click-to-focus, double-click editing, and long-press context menu for adding/removing nodes.
- Add placeholder bottom navigation bar and base styling.

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba185a09a0832e92c2906b5f819be6